### PR TITLE
Added restart feature to UITestRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,8 @@ String contentListStr = TextUtils.listOfRemoteTextToString(contentList);
 ### Use any tool provided by Remote-Robot framework
 Besides the fixtures and utilities provided by this library you can use any tool from the [Remote-Robot](https://github.com/JetBrains/intellij-ui-test-robot) framework itself. 
 
+### Restart feature
+The restart feature allows you to restart IntelliJ IDEA during your UI tests. This can be useful in scenarios where you need to test the behavior of your plugin or application after a restart.
+```
+UITestRunner.restartIde(ideaVersion, portNumber); // returns a remote robot reference
+```

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
@@ -239,7 +239,18 @@ public class FlatWelcomeFrame extends CommonContainerFixture {
         if (UtilsKt.hasAnyComponent(this, byXpath(XPathDefinitions.RECENT_PROJECT_PANEL_NEW))) {
             return button(byXpath(XPathDefinitions.jBOptionButton(label)), Duration.ofSeconds(2));
         }
-        return button(byXpath(XPathDefinitions.nonOpaquePanel(label)), Duration.ofSeconds(2));
+        if (ideaVersion >= 20232) {
+            // code for IntelliJ Idea 2023.2+
+
+            try {
+                return button(byXpath("//div[@defaulticon='createNewProjectTab.svg']"), Duration.ofSeconds(2));
+            } catch (WaitForConditionTimeoutException e) {
+                return button(byXpath(XPathDefinitions.visibleTextLabel(label)), Duration.ofSeconds(2));
+            }
+
+        } else {
+            return button(byXpath(XPathDefinitions.nonOpaquePanel(label)), Duration.ofSeconds(2));
+        }
     }
 
     private ComponentFixture ideErrorsIcon() {

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/constants/XPathDefinitions.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/constants/XPathDefinitions.java
@@ -90,6 +90,10 @@ public class XPathDefinitions {
         return "//div[@text='" + label + "']";
     }
 
+    public static String visibleTextLabel(String label) {
+        return "//div[@visible_text='" + label + "']";
+    }
+
     public static String jBOptionButton(String label) {
         return "//div[@class='JBOptionButton' and @text='" + label + "']";
     }

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/runner/IntelliJVersion.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/runner/IntelliJVersion.java
@@ -26,7 +26,8 @@ public enum IntelliJVersion {
     ULTIMATE_V_2020_2("IU-2020.2"),
     ULTIMATE_V_2020_3("IU-2020.3"),
     ULTIMATE_V_2021_1("IU-2021.1"),
-    ULTIMATE_V_2021_2("IU-2021.2");
+    ULTIMATE_V_2021_2("IU-2021.2"),
+    ULTIMATE_V_2023_2("IU-2023.2");
 
     private final String ideaVersionStringRepresentation;
     private final int ideaVersionIntRepresentation;


### PR DESCRIPTION
**Added restart feature to UITestRunner:**

**Reasons for this:**
- https://github.com/redhat-developer/intellij-openshift-connector/issues/575
- Restart required for successful login when no _/.kube/config_ is present. 
- Used in [intellij-openshift-connector](https://github.com/redhat-developer/intellij-openshift-connector) for IntegrationUITest

**Added:** 

- `restartIde(IntelliJVersion ideaVersion, int port)`
- `findWindowOnStart()` for a little more control. If neither is found exception is thrown.