### PR TITLE
Gradle 7.3 update in test-project & running test jobs with JDK 11

### DIFF
--- a/.github/workflows/dialogs.information_settings.yml
+++ b/.github/workflows/dialogs.information_settings.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         export DISPLAY=:99.0
@@ -50,10 +50,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src/test-project
@@ -83,10 +83,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src\test-project

--- a/.github/workflows/dialogs.project_manipulation.yml
+++ b/.github/workflows/dialogs.project_manipulation.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         export DISPLAY=:99.0
@@ -50,10 +50,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src/test-project
@@ -83,10 +83,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src\test-project

--- a/.github/workflows/dialogs.yml
+++ b/.github/workflows/dialogs.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         export DISPLAY=:99.0
@@ -50,10 +50,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src/test-project
@@ -83,10 +83,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src\test-project

--- a/.github/workflows/mainidewindow.idestatusbar_screenshot.yml
+++ b/.github/workflows/mainidewindow.idestatusbar_screenshot.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         export DISPLAY=:99.0
@@ -66,10 +66,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src/test-project
@@ -99,10 +99,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src\test-project

--- a/.github/workflows/mainidewindow.toolwindowspane.yml
+++ b/.github/workflows/mainidewindow.toolwindowspane.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         export DISPLAY=:99.0
@@ -50,10 +50,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src/test-project
@@ -83,10 +83,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
     - name: Run integration tests
       run: |
         cd src\test-project

--- a/src/test-project/gradle/wrapper/gradle-wrapper.properties
+++ b/src/test-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update of Gradle to version 7.3. in test-project and reverted running testing jobs back to JDK 11.