### PR TITLE
Fix: local build deleted IdeaProjects

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
@@ -32,6 +32,7 @@ import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.settings.Setti
 import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.settings.pages.NotificationsPage;
 import com.redhat.devtools.intellij.commonuitest.utils.constants.XPathDefinitions;
 import com.redhat.devtools.intellij.commonuitest.utils.internalerror.IdeInternalErrorUtils;
+import com.redhat.devtools.intellij.commonuitest.utils.project.CreateCloseUtils;
 import com.redhat.devtools.intellij.commonuitest.utils.runner.IntelliJVersion;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -101,7 +102,7 @@ public class FlatWelcomeFrame extends CommonContainerFixture {
         }
 
         try {
-            String pathToDirToMakeEmpty = System.getProperty("user.home") + File.separator + "IdeaProjects";
+            String pathToDirToMakeEmpty = CreateCloseUtils.PROJECT_LOCATION;
             boolean doesProjectDirExists = Files.exists(Paths.get(pathToDirToMakeEmpty));
             if (doesProjectDirExists) {
                 FileUtils.cleanDirectory(new File(pathToDirToMakeEmpty));

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/project/CreateCloseUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/project/CreateCloseUtils.java
@@ -23,6 +23,7 @@ import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.project.pages.
 import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.MainIdeWindow;
 import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.idestatusbar.IdeStatusBar;
 
+import java.io.File;
 import java.time.Duration;
 
 /**
@@ -31,6 +32,8 @@ import java.time.Duration;
  * @author zcervink@redhat.com
  */
 public class CreateCloseUtils {
+    public static final String PROJECT_LOCATION = System.getProperty("user.home") + File.separator + "IdeaProjects" + File.separator + "intellij-test-projects";
+
     /**
      * Create new project with given project name according to given project type
      *
@@ -62,6 +65,7 @@ public class CreateCloseUtils {
 
         if (UITestRunner.getIdeaVersionInt() >= 20221) {
             newProjectFirstPage.setProjectName(projectName);
+            newProjectFirstPage.setProjectLocation(PROJECT_LOCATION);
         } else {
             newProjectDialogWizard.next();
             // Plain java project has more pages in the 'New project' dialog


### PR DESCRIPTION
Fixed by setting up project location `~/IdeaProjects/intellij-test-projects/`  when creating a project. Also changed the location when clearing the workspace (when intellij starts). Assuming developer is not using said location for his own projects. 