### PR TITLE
Fix: Locally built library deleted contents of IdeaProject folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ runIdeForUiTests {
     systemProperty "robot-server.port", System.getProperty("robot-server.port")
 }
 ```
+### STEP #5: Test project location
+Developers can specify the location where the test project will be created by providing a system property called `testProjectLocation`. For example:
+```
+task integrationTest(type: Test) {
+    ...
+    systemProperties['testProjectLocation'] = '/home/user/IdeaProjects/intellij-ui-test-projects/'
+    ...
+}
+```
+Or add the location as a paramater for gradlew command which runs the test. For example:
+```
+systemProperties['testProjectLocation'] = project.hasProperty('testProjectLocation') ? project.property('testProjectLocation') : null
+    
+./gradlew integrationTest -PtestProjectLocation=${env.HOME}/IdeaProjects/intellij-ui-test-projects/
+```
 
 ## Start and quit IntelliJ IDEA
 Use the following code to start IntelliJ before running the first UI test. The runIde() method not only starts the IDE for UI tests, it also returns reference to the Remote-Robot instance which will be useful later to access UI elements such as buttons, inputs etc.

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/fixtures/dialogs/FlatWelcomeFrame.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;

--- a/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/project/CreateCloseUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/commonuitest/utils/project/CreateCloseUtils.java
@@ -23,7 +23,9 @@ import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.project.pages.
 import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.MainIdeWindow;
 import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.idestatusbar.IdeStatusBar;
 
+import java.io.File;
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * Project creation utilities
@@ -31,6 +33,10 @@ import java.time.Duration;
  * @author zcervink@redhat.com
  */
 public class CreateCloseUtils {
+    public static final String PROJECT_LOCATION = Optional.ofNullable(System.getProperty("testProjectLocation"))        // For more info on testProjectLocation please check README
+            .filter(s -> !s.isEmpty())
+            .orElseGet(() -> System.getProperty("user.home") + File.separator + "IdeaProjects" + File.separator + "intellij-ui-test-projects");
+
     /**
      * Create new project with given project name according to given project type
      *
@@ -62,6 +68,7 @@ public class CreateCloseUtils {
 
         if (UITestRunner.getIdeaVersionInt() >= 20221) {
             newProjectFirstPage.setProjectName(projectName);
+            newProjectFirstPage.setProjectLocation(PROJECT_LOCATION);
         } else {
             newProjectDialogWizard.next();
             // Plain java project has more pages in the 'New project' dialog

--- a/src/test-project/src/test/java/com/redhat/devtools/intellij/commonuitest/fixtures/test/dialogs/FlatWelcomeFrameTest.java
+++ b/src/test-project/src/test/java/com/redhat/devtools/intellij/commonuitest/fixtures/test/dialogs/FlatWelcomeFrameTest.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.FlatWelcomeFra
 import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.project.NewProjectDialogWizard;
 import com.redhat.devtools.intellij.commonuitest.utils.constants.XPathDefinitions;
 import com.redhat.devtools.intellij.commonuitest.utils.internalerror.IdeInternalErrorUtils;
+import com.redhat.devtools.intellij.commonuitest.utils.project.CreateCloseUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -77,9 +78,13 @@ class FlatWelcomeFrameTest extends LibraryTestBase {
     }
 
     private int getNumberOfProjectsOnDisk() {
-        String pathToIdeaProjectsFolder = System.getProperty("user.home") + File.separator + "IdeaProjects";
+        String pathToIdeaProjectsFolder = CreateCloseUtils.PROJECT_LOCATION;
         File[] files = new File(pathToIdeaProjectsFolder).listFiles((FileFilter) FileFilterUtils.directoryFileFilter());
-        return files.length;
+        if (files != null) {
+            return files.length;
+        } else {
+            return 0;   // files is null (e.g., folder doesn't exist)
+        }
     }
 
     private int getNumberOfProjectLinks() {


### PR DESCRIPTION
Running [common-ui-test-library](https://github.com/redhat-developer/intellij-common-ui-test-library) locally would delete contents of `~/IdeaProjects`
Fixed by setting up **default** project location `~/IdeaProjects/intellij-ui-test-projects/`  when creating a project. Also changed the location when clearing the workspace (when intellij starts). Assuming developer is not using said location for his own projects. 

Developers are now also able to specify test-project location by providing a system property: `testProjectLocation` to a path where you want UI test project to be created.
