### PR TITLE
build(deps): Revert com.intellij.remoterobot:remote-robot back to 0.11.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     api 'commons-io:commons-io:2.16.1'
     api 'org.junit.jupiter:junit-jupiter-api:5.10.3'
     api 'org.junit.jupiter:junit-jupiter-engine:5.10.3'
-    api "com.intellij.remoterobot:remote-robot:0.11.23"
+    api "com.intellij.remoterobot:remote-robot:0.11.22"
     api "com.intellij.remoterobot:remote-fixtures:0.11.22"
 }
 


### PR DESCRIPTION
This reverts commit 642c765f84e5c205b7522f9d914829f5783b4c73.

Reverting because of #262 