### PR TITLE
chore: fix publish and bump version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 #!/usr/bin/env groovy
 
 node('rhel7') {
+	def javaHome = tool 'openjdk-17'
+	env.JAVA_HOME = "${javaHome}"
+
     stage('Checkout repo') {
         deleteDir()
         git url: 'https://github.com/redhat-developer/intellij-common-ui-test-library',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-projectVersion=0.4.2
+projectVersion=0.4.3-SNAPSHOT
 nexusUser=invalid
 nexusPassword=invalid


### PR DESCRIPTION
with this fix, we can use a 0.4.3-snapshot in dependent extensions.